### PR TITLE
El anexo2 se puede generar con datos de empresa incompletos o vacíos.

### DIFF
--- a/anexo2/docs.py
+++ b/anexo2/docs.py
@@ -89,13 +89,19 @@ class Anexo2:
         fva = data['obra_social']['fecha_de_vencimiento']['anio']
         data['obra_social']['__fva'] = self._str_to_boxes(txt=fva, total_boxes=4, fill_with='')
         
-        ursm = data['empresa']['ultimo_recibo_de_sueldo']['mes']
-        data['empresa']['__ursm'] = self._str_to_boxes(txt=ursm, total_boxes=2, fill_with='0')
+        # En caso de no existir los valores se pasan strings vacíos al HTML
+        try:
+            ursm = data['empresa']['ultimo_recibo_de_sueldo']['mes']
+            data['empresa']['__ursm'] = self._str_to_boxes(txt=ursm, total_boxes=2, fill_with='0')
+        except KeyError:
+            data['empresa']['__ursm'] = self._str_to_boxes(txt='', total_boxes=2, fill_with='')
 
-        ursa = data['empresa']['ultimo_recibo_de_sueldo']['anio']
-        data['empresa']['__ursa'] = self._str_to_boxes(txt=ursa, total_boxes=4, fill_with='')
+        try:
+            ursa = data['empresa']['ultimo_recibo_de_sueldo']['anio']
+            data['empresa']['__ursa'] = self._str_to_boxes(txt=ursa, total_boxes=4, fill_with='')
+        except KeyError:
+            data['empresa']['__ursa'] = self._str_to_boxes(txt='', total_boxes=4, fill_with='')
 
-        
 
         return data
 
@@ -180,6 +186,7 @@ class Anexo2:
                 },
             'empresa': {
                 'type': 'dict',
+                'nullable': True,
                 'schema': {
                     'nombre': {'type': 'string'},
                     'direccion': {'type': 'string'},

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='anexo2',
-     version='1.0.20',
+     version='1.0.21',
      license='MIT',
      author="Andres Vazquez",
      author_email="andres@data99.com.ar",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,8 +1,9 @@
+import pytest
 from anexo2.docs import Anexo2
 
 
-def test_base():
-
+@pytest.fixture
+def anexo2_data() -> dict:
     hospital = {'nombre': 'HOSPITAL SAN ROQUE',  # https://www.sssalud.gob.ar/index.php?page=bus_hosp&cat=consultas
             'codigo_hpgd': '4321323'}
             
@@ -41,7 +42,47 @@ def test_base():
             'obra_social': obra_social,
             'empresa': empresa
             }
+    
+    return data
 
-    anx = Anexo2(data=data)
+
+def test_base(anexo2_data):
+    """ El Anexo2 completo se genera correctamente """
+
+    anx = Anexo2(data=anexo2_data)
+    res = anx.get_html()
+    assert res is not None
+
+
+def test_empresa_vacia(anexo2_data):
+    """ El Anexo2 sin datos de la empresa se genera sin errores"""
+
+    empresa_vacia = {
+        'empresa': {}
+        }
+
+    # Reemplazamos los datos de la empresa por los datos vacíos
+    anexo2_data.update(empresa_vacia)
+
+    anx = Anexo2(data=anexo2_data)
+    res = anx.get_html()
+    assert res is not None
+
+
+def test_empresa_incompleta(anexo2_data):
+    """ El Anexo2 se genera sin errores a pesar de que le faltan los datos del ult. recibo de sueldo """
+
+    empresa_incompleta = {
+        'empresa': {
+                'nombre': 'Telescopios Hubble',
+                'direccion': 'Av Astronómica s/n',
+                'cuit': '31-91203043-8'
+            }
+    }
+
+    anexo2_data.update(empresa_incompleta)
+
+
+    anx = Anexo2(data=anexo2_data)
     res = anx.get_html()
     assert res is not None


### PR DESCRIPTION
Fixes #10 
- Agregué un fixture en tests para reutilizar data de ejemplo

### Datos incompletos
![imagen](https://user-images.githubusercontent.com/19599150/93550624-2b6ddf00-f942-11ea-85e4-acaaec117e0e.png)

### Sin datos
![imagen](https://user-images.githubusercontent.com/19599150/93531327-6e658d80-f915-11ea-91a0-4975017d5657.png)