### PR TITLE
[FIX] Permitir valores nulos en campos del recibo de sueldo

### DIFF
--- a/anexo2/docs.py
+++ b/anexo2/docs.py
@@ -49,6 +49,24 @@ class Anexo2:
         return r, self.validator.errors
     
     def _str_to_boxes(self, txt, total_boxes, fill_with=''):
+        """
+            Toma un str (día, mes, año) y lo convierte en una lista
+            de caractéres para ser renderizado en el template.
+
+            Si `txt` ocupa menos que `total_boxes` se llena 
+            con `fill_with` lo que sobra.
+        """
+
+        # En caso de que txt sea None pasamos una lista vacía al template
+        if txt is None:
+            txt = ''
+            fill_with = ''
+
+            ret = [fill_with for r in range(total_boxes - len(txt))]
+            ret += list(txt)
+
+            return ret
+
         # fit a text in a group of boxes
         if type(txt) != str:
             txt = str(txt)
@@ -127,35 +145,38 @@ class Anexo2:
                     'tipo_beneficiario': {'type': 'string', 'allowed': ['titular', 'no titular', 'adherente']},
                     'parentesco': {'type': 'string', 'allowed': ['conyuge', 'hijo', 'otro']},
                     'sexo': {'type': 'string', 'allowed': ['F', 'M']},
-                    'edad': {'type': 'integer', 'min': 0, 'max': 110}
+                    'edad': {'type': 'integer', 'nullable': True, 'min': 0, 'max': 110}
                     }
                 },
             'atencion': {
                 'type': 'dict',
                 'schema': {
-                    'tipo': {'type': 'list', 'allowed': ['consulta', 'práctica', 'internación']},
+                    'tipo': {
+                        'type': 'list',
+                        'allowed': ['consulta', 'práctica', 'internación']
+                    },
                     'profesional': {
                         'type': 'dict',
                         'schema': {
                             'apellido_y_nombres': {'type': 'string'},
-                            'matricula_profesional': {'type': 'string'},
+                            'matricula_profesional': {'type': 'string', 'nullable': True,},
                         },
                     },
-                    'especialidad': {'type': 'string'},
-                    'codigos_N_HPGD': {'type': 'list'},
+                    'especialidad': {'type': 'string', 'nullable': True,},
+                    'codigos_N_HPGD': {'type': 'list', 'nullable': True,},
                     'fecha': {
                         'type': 'dict',
                         'schema': {
-                            'dia': {'type': 'integer', 'min': 1, 'max': 31},
-                            'mes': {'type': 'integer', 'min': 1, 'max': 12},
-                            'anio': {'type': 'integer', 'min': 2019, 'max': 2030}
+                            'dia': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 31},
+                            'mes': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 12},
+                            'anio': {'type': 'integer', 'nullable': True, 'min': 2019, 'max': 2030}
                             }
                         },
                     'diagnostico_ingreso_cie10': {
                         'type': 'dict',
                         'schema': {
                             'principal': {'type': 'string'}, 
-                            'otros': {'type': 'list'}
+                            'otros': {'type': 'list', 'nullable': True,}
                             }
                         }
                     }
@@ -165,21 +186,21 @@ class Anexo2:
                 'schema': {
                     'codigo_rnos': {'type': 'string'},
                     'nombre': {'type': 'string'},
-                    'nro_carnet_obra_social': {'type': 'string'},
+                    'nro_carnet_obra_social': {'type': 'string', 'nullable': True,},
                     'fecha_de_emision': {
                         'type': 'dict',
                         'schema': {
-                            'dia': {'type': 'integer', 'min': 1, 'max': 31},
-                            'mes': {'type': 'integer', 'min': 1, 'max': 12},
-                            'anio': {'type': 'integer', 'min': 1970, 'max': 2030}
+                            'dia': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 31},
+                            'mes': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 12},
+                            'anio': {'type': 'integer', 'nullable': True, 'min': 1970, 'max': 2030}
                             }
                         },
                     'fecha_de_vencimiento': {
                         'type': 'dict',
                         'schema': {
-                            'dia': {'type': 'integer', 'min': 1, 'max': 31},
-                            'mes': {'type': 'integer', 'min': 1, 'max': 12},
-                            'anio': {'type': 'integer', 'min': 2019, 'max': 2030}
+                            'dia': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 31},
+                            'mes': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 12},
+                            'anio': {'type': 'integer', 'nullable': True, 'min': 2019, 'max': 2030}
                             }
                         },
                     }
@@ -189,7 +210,7 @@ class Anexo2:
                 'nullable': True,
                 'schema': {
                     'nombre': {'type': 'string'},
-                    'direccion': {'type': 'string'},
+                    'direccion': {'type': 'string', 'nullable': True,},
                     'ultimo_recibo_de_sueldo': {
                         'type': 'dict',
                         'schema': {
@@ -197,7 +218,7 @@ class Anexo2:
                             'anio': {'type': 'integer', 'nullable': True, 'min': 1970, 'max': 2030}
                             }
                         },
-                    'cuit': {'type': 'string'}
+                    'cuit': {'type': 'string', 'nullable': True,}
                     }
                 }
         }
@@ -228,10 +249,10 @@ if __name__ == '__main__':
                     'apellido_y_nombres': 'Adolfo Martínez',
                     'matricula_profesional': '10542',
                 },
-                'especialidad': 'Va un texto al parecer largo, quizas sea del nomenclador',
+                'especialidad': 'Odontología',
                 'codigos_N_HPGD': ['AA01', 'AA02', 'AA06', 'AA07'],  # no se de donde son estos códigos
                 'fecha': {'dia': 3, 'mes': 9, 'anio': 2019},
-                'diagnostico_ingreso_cie10': {'principal': 'W020', 'otros': ['w021', 'A189']}
+                'diagnostico_ingreso_cie10': {'principal': 'W020', 'otros': ['W021', 'A189']}
                 },
             'obra_social': {
                 'codigo_rnos': '800501',

--- a/anexo2/docs.py
+++ b/anexo2/docs.py
@@ -193,9 +193,8 @@ class Anexo2:
                     'ultimo_recibo_de_sueldo': {
                         'type': 'dict',
                         'schema': {
-                            'dia': {'type': 'integer', 'min': 1, 'max': 31},
-                            'mes': {'type': 'integer', 'min': 1, 'max': 12},
-                            'anio': {'type': 'integer', 'min': 1970, 'max': 2030}
+                            'mes': {'type': 'integer', 'nullable': True, 'min': 1, 'max': 12},
+                            'anio': {'type': 'integer', 'nullable': True, 'min': 1970, 'max': 2030}
                             }
                         },
                     'cuit': {'type': 'string'}

--- a/anexo2/templates/anexo2.html
+++ b/anexo2/templates/anexo2.html
@@ -162,10 +162,10 @@
         <td class="s5" colspan="2" rowspan="2">{% if 'consulta' in atencion.tipo %}X{% endif %}</td>
         <td class="s5" rowspan="6"></td>
         <td class="s4" dir="ltr" colspan="5" rowspan="2">Especialidad</td>
-        <td class="f5 s5" colspan="20" rowspan="2">{{ atencion.especialidad }}</td>
-        <td class="s5" colspan="2" rowspan="2">{{ atencion.fecha.dia }}</td>
-        <td class="s5" colspan="2" rowspan="2">{{ atencion.fecha.mes }}</td>
-        <td class="s5" colspan="2" rowspan="2">{{ atencion.fecha.anio }}</td>
+        <td class="f5 s5" colspan="20" rowspan="2">{{ atencion.especialidad|default('', true) }}</td>
+        <td class="s5" colspan="2" rowspan="2">{{ atencion.fecha.dia|default('', true) }}</td>
+        <td class="s5" colspan="2" rowspan="2">{{ atencion.fecha.mes|default('', true) }}</td>
+        <td class="s5" colspan="2" rowspan="2">{{ atencion.fecha.anio|default('', true) }}</td>
       </tr>
       <tr style='height:20px;'>
         
@@ -212,7 +212,7 @@
       
       <tr style='height:20px;'>
         <td class="s4" dir="ltr" colspan="39" style="border-left: 1px SOLID #000000;">
-          Firma del Médico y Sello con Nº de Matrícula - {{ atencion.profesional.apellido_y_nombres }} - MP.: {{ atencion.profesional.matricula_profesional }}
+          Firma del Médico y Sello con Nº de Matrícula - {{ atencion.profesional.apellido_y_nombres }} - MP.: {{ atencion.profesional.matricula_profesional|default('', true) }}
         </td>
       </tr>
       

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='anexo2',
-     version='1.0.21',
+     version='1.0.22',
      license='MIT',
      author="Andres Vazquez",
      author_email="andres@data99.com.ar",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -87,3 +87,66 @@ def test_empresa_incompleta(anexo2_data):
     anx = Anexo2(data=anexo2_data)
     res = anx.get_html()
     assert res is not None
+
+def test_beneficiario_incompleto(anexo2_data):
+    """ El Anexo2 se genera sin errores con la edad del paciente nula """
+
+    beneficiario_incompleto = {
+        'beneficiario': {
+                'apellido_y_nombres': 'Juan Perez',
+                'tipo_dni': 'LE',  # DNI | LE | LC
+                'dni': '34100900',
+                'tipo_beneficiario': 'titular',  # | no titular | adherente
+                'parentesco': 'conyuge',  # hijo | otro
+                'sexo': 'M',  # | F
+                'edad': None,
+            }
+    }
+
+    anexo2_data.update(beneficiario_incompleto)
+
+    anx = Anexo2(data=anexo2_data)
+    res = anx.get_html()
+    assert res is not None
+
+def test_atencion_incompleta(anexo2_data):
+    """ El Anexo2 se genera sin errores con varios valores nulos en la atención """
+
+    atencion_incompleto = {
+        'atencion': {
+                'tipo': ['consulta', 'práctica', 'internación'],
+                'profesional': {
+                    'apellido_y_nombres': 'Adolfo Martínez',
+                    'matricula_profesional': None,
+                },
+                'especialidad': None,
+                'codigos_N_HPGD': None,
+                'fecha': {'dia': None, 'mes': None, 'anio': None},
+                'diagnostico_ingreso_cie10': {'principal': 'W020', 'otros': None}
+            }
+    }
+
+    anexo2_data.update(atencion_incompleto)
+
+    anx = Anexo2(data=anexo2_data)
+    res = anx.get_html()
+    assert res is not None
+
+def test_obra_social_incompleta(anexo2_data):
+    """ El Anexo2 se genera sin errores con varios valores nulos en la Obra Social """
+
+    obra_social_incompleta = {
+        'obra_social': {
+                'codigo_rnos': '800501',
+                'nombre': 'OBRA SOCIAL ACEROS PARANA',
+                'nro_carnet_obra_social': None,
+                'fecha_de_emision': {'dia': None, 'mes': None, 'anio': None},
+                'fecha_de_vencimiento': {'dia': None, 'mes': None, 'anio': None}
+            }
+    }
+
+    anexo2_data.update(obra_social_incompleta)
+
+    anx = Anexo2(data=anexo2_data)
+    res = anx.get_html()
+    assert res is not None

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -76,7 +76,8 @@ def test_empresa_incompleta(anexo2_data):
         'empresa': {
                 'nombre': 'Telescopios Hubble',
                 'direccion': 'Av Astronómica s/n',
-                'cuit': '31-91203043-8'
+                'cuit': '31-91203043-8',
+                'ultimo_recibo_de_sueldo': {'mes': None, 'anio': None},
             }
     }
 


### PR DESCRIPTION
Campos que pueden ser nulos para Anexo2 (Esto se basa en los campos **requeridos** en los modelos del sistema)

- Beneficiario
    - Edad
- Atención
    - Profesional
        - matricula_profesional
    - Especialidad (Puede estar vacía)
    - Códigos N HPGD → Son los códigos de las prestaciones (Pueden estar vacíos)
    - Fecha de atención (día, mes, año)
    - Códigos Cie secundarios
    - Obra Social
        - Nro Afiliado
        - Fecha de emisión (día, mes, año)
        - Fecha de vencimiento (día, mes, año)
    - Empresa (Puede estar vacía)
        - Dirección
        - Ultimo recibo de sueldo (mes, año)
        - CUIT

Si no se me escapa nada, esto es lo más vacío que puede estar un Anexo2.
![imagen](https://user-images.githubusercontent.com/19599150/93844052-54f47680-fc72-11ea-8705-ff33c4454082.png)


